### PR TITLE
Migrated Swedish terminology list from Taiga

### DIFF
--- a/swedish-terminology.md
+++ b/swedish-terminology.md
@@ -1,0 +1,48 @@
+#### This is a page created by ordtrogen for collaboration on terminology between Swedish translators
+
+Min idé är att använda denna sida för att kunna enas om en gemensam terminologi för oss översättare mellan olika projekt: daemon, GUI, Monerujo, webbplats, wikipedia etc. 
+
+| **engelska** | **svenska** | **betydelse** | **kommentar** | **referens** |
+| --- | --- | --- | --- | --- |
+| anonymity set | anonymitetsuppsättning | | | |
+| blockchain | blockkedja | | | https://it-ord.idg.se/ord/blockkedja/|
+| block height | blockhöjd | antal block mellan aktuellt block och det första blocket i kedjan | Hade kunna heta "längd" men nu heter det höjd | |
+| block reward | blockbelöning | En ersättning i form av ett antal monero som tillfaller den brytare som lyckas lösa ett block. En kombination av "nya" monero och de transaktionsavgifter som ingår i blocket. | | https://it-ord.idg.se/ord/blockbeloning/|
+| block time | blocktid | Tid mellan två block. Nätverket försöker upprätthålla en genomsnittlig tid mellan att två block löses genom att göra det svårare/lättare att lösa block, beroende på hur många noder som utför brytning. | | https://it-ord.idg.se/ord/blocktid/|
+| change | växel | | | |
+| coinbase transaction | coinbase-transaktion | en transaktion som brytaren inkluderar i det nya blocket och som överför blockbelöningen till en av denne vald adress| | |
+| [Pedersen] commitment | | | | |
+| confidential transaction | konfidentiell transaktion | en transaktion som är dold på blockkedjan | | |
+| confirmation | bekräftelse | | | |
+| cryptocurrency | kryptovaluta | | | |
+| dust | damm | | | |
+| emission | utgivning | En del av blockbelöningen utgörs av nya monero som ökar den tillgängliga penningmängden. Uppkomsten av dessa kallas "utgivning"| | |
+| tail emission | svansutgivning | Det antal nya monero som ingår i blockbelöningen (utöver transaktionsavgifterna) minskar hela tiden, men når aldrig noll. Den slutliga utgivningstakten kallas "svansutgivning" eftersom den kan ses som en lång svans på utgivningskurvan | | |
+| fork | förgrening | när en blockkedja delas (förgrenas) och en ny, separat valuta och blockkedja skapas | |https://it-ord.idg.se/ord/forgrening/|
+| fungible | fungibel | | | https://it-ord.idg.se/?s=fungibel |
+| fungibility | fungibilitet | | | https://it-ord.idg.se/?s=fungibel|
+| integrated address | integrerad adress | | | |
+| ledger | liggare | | Blockkedjan utgör ett register, en "liggare", över alla transaktioner som ägt rum. Jfr "hotelliggare"| https://it-ord.idg.se/ord/liggare/ |
+| mine | bryta | Processen att lösa nya block och sedan skicka dem till nätverket för att läggas till blockkedjan. Den brytare som lyckas lösa ett block får en blockbelöning och processen liknas i Nakamotos vitbok vid "Gold mining".|Det finns tyvärr ingen etablerad term för detta inom området kryptovaluta. |"gruvbrytning" http://iate.europa.eu|
+| miner | brytare | | | |
+| mining | brytning | | | |
+| mnemonic seed | mnemotekniskt frö | | | http://iate.europa.eu/ |
+| payment ID | betalnings-ID | | | |
+| proof-of-work | bevis-på-arbete | | | https://it-ord.idg.se/ord/bevis-pa-arbete/|
+| public/private key | öppen/privat nyckel | | |http://www.termado.com/DatatermSearch/?ss=public https://it-ord.idg.se/ord/oppen-nyckel/|
+| restore | återställa | t ex återställa en plånbok från en säkerhetskopia| | Microsoft Language Portal |
+| restore height | återställningshöjd | | | | 
+| ring confidential transaction (Ring CT) | | | | |
+| ring signature | ringsignatur | | | |
+| scalable | skalbar | I området kryptovaluta, förmågan hos ett nätverk att hantera allt större transaktionsvolymer| |https://it-ord.idg.se/ord/skalbarhet/ |
+| scalability | skalbarhet | | | https://it-ord.idg.se/ord/skalbarhet/|
+| seed | frö | | | |
+| spend key | spendernyckel | Den kryptografiska nyckel som används för att signera en transaktion som skickar pengar från en adress i Moneros blockkedja | |Varför "spendera" för "spend":  https://it-ord.idg.se/ord/dubbelspendering/ |
+| stealth address | smygadress | | | https://sv.wikipedia.org/wiki/Smygteknik |
+| subaddress | underadress | | | |
+| transaction | transaktion | | ||
+| transaction unlock time | | | ||
+| output | utgång | belopp som kom ut från tidigare tx | | |
+| unlocked balance | upplåst saldo | efter en transaktion är dess saldo låst, och låses upp först efter ett antal bekräftelser | | |
+| view key | granskningsnyckel | Den kryptografiska nyckel som kan användas för att granska saldot på en adress i Moneros blockkedja | | |
+| wallet | plånbok | | | |


### PR DESCRIPTION
Includes a clean-up and several edits and new references to sources.
