### PR TITLE
rewards: add payment to lh1008

### DIFF
--- a/rewards.md
+++ b/rewards.md
@@ -13,3 +13,4 @@ View key of the wallet: *cad2c29dca7c15a8627d0685004a0a8641727a2bb956d4d40b680be
 | algo_max | 0.5 | Review of user guides translated into German (on Github) |
 | el00ruobuob | 0.5 | Review of stale suggestions and reverted strings of low quality made by (CCS-funded) French translators on Weblate |
 | xmronadaily| 0.5 | rework of all the strings submitted by a low quality translator (Serbian) |
+| lh1008 | 0.5 | Review of Spanish (CCS-funded) translations |


### PR DESCRIPTION
This reward was agreed whrn the value of Monero was much lower. Next rewards will be adapted according to the value of XMR.